### PR TITLE
Add Fields to Fetch and Add Content to BookItemBack

### DIFF
--- a/src/components/BookItem.jsx
+++ b/src/components/BookItem.jsx
@@ -1,57 +1,104 @@
 import * as React from "react";
 import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
 import CardMedia from "@mui/material/CardMedia";
-import CardActions from "@mui/material/CardActions";
-import BookItemBack from "./BookItemBack";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import IosShareRoundedIcon from '@mui/icons-material/IosShareRounded';
+import FlipToBackRoundedIcon from '@mui/icons-material/FlipToBackRounded';
+import FlipToFrontRoundedIcon from '@mui/icons-material/FlipToFrontRounded';
 
 export default function BookItem({ book }) {
-  const { title, authors, imageLinks, canonicalVolumeLink } = book.volumeInfo;
-  const [open, setOpen] = React.useState(false);
+  const { title, authors, imageLinks, canonicalVolumeLink, pageCount, categories } = book.volumeInfo;
+  const [flipped, setFlipped] = React.useState(false);
 
-  const handleOpen = () => setOpen(true);
-  const handleClose = () => setOpen(false);
+  const handleFlip = () => setFlipped(!flipped);
 
   const cardStyle = {
     width: 200,
     paddingTop: 2,
-    paddingLeft: 1,
-    paddingRight: 1,
-    backgroundColor: "#E09F3E",
+    backgroundColor: "#fff",
+    borderRadius: "10px",
+    boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+    height: 350,
+  };
+
+  const titleStyle = {
+    fontSize: "1rem",
+    fontWeight: "bold",
+    color: "#3A3A3A",
+  };
+
+  const authorStyle = {
+    fontSize: "0.9rem",
+    color: "#7B7B7B",
   };
 
   return (
-    <div>
-      <Card sx={cardStyle} onClick={handleOpen}>
-        <CardMedia
-          component="img"
-          sx={{ objectFit: "contain" }}
-          height="200"
-          image={imageLinks?.thumbnail?.replace(/&edge=curl/g, "")}
-          alt={`Cover of ${title} by ${authors?.join(", ")}`}
-        />
-        <CardActions
-          disableSpacing
+    <Card sx={cardStyle}>
+      {!flipped ? (
+        <CardActionArea component="a" href={canonicalVolumeLink} target="_blank" sx={{ height: "100%" }}>
+          <CardMedia
+            component="img"
+            sx={{ objectFit: "contain" }}
+            height="200"
+            image={imageLinks?.thumbnail?.replace(/&edge=curl/g, "")}
+            alt={`Cover of ${title} by ${authors?.join(", ")}`}
+          />
+          <CardContent sx={{ padding: "8px", textAlign: "center" }}>
+            <Typography
+              variant="body1"
+              sx={{
+                ...titleStyle,
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 3, // Limit to 3 lines
+                WebkitBoxOrient: "vertical",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography variant="body2" sx={authorStyle}>
+              {authors?.join(", ")}
+            </Typography>
+          </CardContent>
+        </CardActionArea>
+      ) : (
+        <CardContent sx={{ textAlign: "center" }}>
+          <Typography variant="body2">Page Count: {pageCount}</Typography>
+          <Typography variant="body2">Categories: {categories?.join(", ")}</Typography>
+        </CardContent>
+      )}
+
+      <div className="flex flex-row justify-between" >
+        {/* Flip Button */}
+        <Button onClick={handleFlip}
           sx={{
-            height: "2rem",
-            padding: 1,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
+            border: "none", // Remove border
+            boxShadow: "none", // Remove any shadow that may appear as a border
+            '&:hover': {
+              backgroundColor: "#f0f0f0", // Optional: change background on hover
+              boxShadow: "none", // Remove shadow on hover
+            },
+            '&:focus': {
+              outline: "none", // Remove focus outline
+              boxShadow: "none", // Remove shadow on focus
+            }
           }}
         >
-          <MoreHorizIcon sx={{ height: "2em", width: "2em" }} />
-        </CardActions>
-      </Card>
-      <BookItemBack
-        title={title}
-        authors={authors}
-        canonicalVolumeLink={canonicalVolumeLink}
-        open={open}
-        handleClose={handleClose}
-        width={cardStyle.width}
-        height={264}
-      />
-    </div>
+          {flipped ? <FlipToFrontRoundedIcon /> : <FlipToBackRoundedIcon />}
+        </Button>
+
+        {/* Share Button */}
+        <Button href={canonicalVolumeLink} target="_blank">
+          <IosShareRoundedIcon />
+        </Button>
+      </div>
+    </Card>
   );
 }

--- a/src/hooks/useFetchBooks.js
+++ b/src/hooks/useFetchBooks.js
@@ -14,7 +14,7 @@ const useFetchBooks = (searchParams) => {
 
     const fetchData = async () => {
       setLoading(true);
-      setError(null);  // Clear error before starting new request
+      setError(null); // Clear error before starting new request
       setSuccess(false);
       const baseUrl = "https://www.googleapis.com/books/v1/volumes";
       const key = import.meta.env.VITE_GOOGLE_BOOKS_API_KEY;
@@ -41,19 +41,23 @@ const useFetchBooks = (searchParams) => {
       const fetchUrl = `${baseUrl}?q=${queryParam}&maxResults=40&langRestrict=${searchParams.language}&printType=books&orderBy=${apiSortType}&fields=items(id,volumeInfo(title,authors,description,imageLinks,canonicalVolumeLink,categories,publishedDate,publisher,pageCount,averageRating))&key=${key}`;
 
       try {
-        const controller = new AbortController();  // Create an abort controller to manage timeouts
-        const timeoutId = setTimeout(() => controller.abort(), 10000);  // 10 second timeout
+        const controller = new AbortController(); // Create an abort controller to manage timeouts
+        const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
         const response = await fetch(fetchUrl, { signal: controller.signal });
-        clearTimeout(timeoutId);  // Clear timeout if fetch succeeds
+        clearTimeout(timeoutId); // Clear timeout if fetch succeeds
 
         if (!response.ok) {
           // Handle HTTP status codes
           switch (response.status) {
             case 400:
-              throw new Error("Bad request. Please check your search parameters.");
+              throw new Error(
+                "Bad request. Please check your search parameters."
+              );
             case 403:
-              throw new Error("API key is invalid or you have exceeded your quota.");
+              throw new Error(
+                "API key is invalid or you have exceeded your quota."
+              );
             case 404:
               throw new Error("No books found. Please try a different search.");
             case 500:
@@ -72,7 +76,8 @@ const useFetchBooks = (searchParams) => {
 
         let uniqueBooks = data.items.filter(
           (item, index, self) =>
-            index === self.findIndex((t) => t.volumeInfo.title === item.volumeInfo.title)
+            index ===
+            self.findIndex((t) => t.volumeInfo.title === item.volumeInfo.title)
         );
 
         if (searchParams.sortType === "newest") {
@@ -85,7 +90,6 @@ const useFetchBooks = (searchParams) => {
 
         setBooks(uniqueBooks);
         setSuccess(true);
-
       } catch (err) {
         if (err.name === "AbortError") {
           setError("Request timed out. Please try again.");


### PR DESCRIPTION
1. Move title and author/-s to [BookItem](https://github.com/livoszlak/book-finder-api-2.0/blob/main/src/components/BookItem.jsx) - but please make sure both will fit above or beneath cover image, in a way that doesn't mess with the styling cohesion. Title and author/-s should have the same space on every BookItem card, and cover image should also maintain consistent space on the card. In v1 of this project, I solved the issue of different lengths of titles and author names with having them "disappear" under ellipses, but perhaps you have a better solution?

 2. Having moved title and author from the back view of the card, display Page count and categories there instead. And perhaps description can appear in an additional BookItemBack component if user clicks a "See description"-button? Check out [Nested modal](https://mui.com/material-ui/react-modal/) - is it possible to have the child modal appear next to the parent modal? Side by side, sliding in from right? Let's find out!
 
 3. If "See description" child modal is implemented, perhaps replace the link icon on the back view of the parent modal with a "View on Google Books" button?
 

[
![Screenshot 2024-10-18 223727](https://github.com/user-attachments/assets/6afbb5a5-76f1-43a3-b1ca-0e5009971a3a)
](
![Screenshot 2024-10-18 223736](https://github.com/user-attachments/assets/b72e3a15-530b-47d6-8cc3-064df059f05a)
url)